### PR TITLE
fix: eliminate infinite loop error

### DIFF
--- a/src/com/deepak/data/structures/LinkedList/CircularLinkedList.java
+++ b/src/com/deepak/data/structures/LinkedList/CircularLinkedList.java
@@ -44,9 +44,12 @@ public class CircularLinkedList<E> {
 			head = newNode;
 			head.next = head;
 		} else {
+			newNode.next = head;
 			Node<E> temp = head;
-			newNode.next = temp;
-			head = newNode;
+			while (temp.next != head) {
+				temp = temp.next;
+			}
+			temp.next = newNode;
 		}
 		size++;
 	}


### PR DESCRIPTION
when I tried running display after using the insertAtBeginning(E value) function to populate the LinkedList, I was sent to an infinite loop. I fixed it by properly linking the final node to the head element.